### PR TITLE
QoL: improves typings for @Component and AbstractComponent

### DIFF
--- a/src/classes/abstract.component.ts
+++ b/src/classes/abstract.component.ts
@@ -1,53 +1,54 @@
-import {Template} from "./template";
-import {HtmlElementUtility} from "../helpers/html-element-utility";
+import type { ComponentOptions } from "../decorators/component.decorator";
+import { HtmlElementUtility } from "../helpers/html-element-utility";
+import { Template } from "./template";
 
 /**
  * @description
  * Basically any Component that is created via the Component-Decorator implements this Interface implicit via Type casting
  */
-export abstract class AbstractComponent {
-	[index: string]: any;
+export abstract class AbstractComponent<TComponentOptions extends ComponentOptions = ComponentOptions> {
+  [index: string]: any;
 
-	/**
-	 * @description
-	 * Contains the value of the component selector of the element.
-	 */
-	get identifier(): string {
-		return HtmlElementUtility.getSelectorValue(this.selector, this.element);
-	}
+  /**
+   * @description
+   * Contains the value of the component selector of the element.
+   */
+  get identifier(): string {
+    return HtmlElementUtility.getSelectorValue(this.selector, this.element);
+  }
 
-	/**
-	 * @description
-	 * The Element that was found in the DOM on DomReady for the given selector
-	 */
-	element: Element;
-	/**
-	 * @description
-	 * This property will be filled automatically if the class was decorated by the Component Decorator.
-	 * It contains the passed selector string.
-	 */
-	selector: string;
-	/**
-	 * @description
-	 * The HTML of the Template that is found if the Component Decorator was correctly configured.
-	 * @see Component
-	 */
-	template: Template;
-	/**
-	 * @description
-	 * The Elements that are found by the childSelectors configured by the Component Decorator
-	 */
-	children: any;
-	/**
-	 * @description
-	 * The complete Configuration passed to the Component Decorator.
-	 * Two underscores, because its not meant to be used outside of the framework
-	 */
-	__options: any;
-	/**
-	 * @description
-	 * A property that contains all listeners for component class initialization.
-	 * Two underscores, because its not meant to be used outside of the framework
-	 */
-	// __componentClassInitializedListeners: ((componentObject: AbstractComponent) => void)[] = [];
+  /**
+   * @description
+   * The Element that was found in the DOM on DomReady for the given selector
+   */
+  element: Element;
+  /**
+   * @description
+   * This property will be filled automatically if the class was decorated by the Component Decorator.
+   * It contains the passed selector string.
+   */
+  selector: string;
+  /**
+   * @description
+   * The HTML of the Template that is found if the Component Decorator was correctly configured.
+   * @see Component
+   */
+  template: Template;
+  /**
+   * @description
+   * The Elements that are found by the childSelectors configured by the Component Decorator
+   */
+  children: { [key in TComponentOptions["childrenSelectors"][number]]: Element[] };
+  /**
+   * @description
+   * The complete Configuration passed to the Component Decorator.
+   * Two underscores, because its not meant to be used outside of the framework
+   */
+  __options: TComponentOptions;
+  /**
+   * @description
+   * A property that contains all listeners for component class initialization.
+   * Two underscores, because its not meant to be used outside of the framework
+   */
+  // __componentClassInitializedListeners: ((componentObject: AbstractComponent) => void)[] = [];
 }

--- a/src/decorators/component.decorator.ts
+++ b/src/decorators/component.decorator.ts
@@ -1,4 +1,17 @@
-import {AbstractComponent} from "../classes/abstract.component";
+import { AbstractComponent } from "../classes/abstract.component";
+
+export type ComponentOptions = {
+  selector: string;
+  childrenSelectors?: readonly string[];
+  template?: string;
+  templateUrl?: string;
+  templateCachingEnabled?: boolean;
+  restrict?: string;
+};
+
+export interface Constructor<T> {
+  new (...args: any[]): T;
+}
 
 /**
  * @description
@@ -6,20 +19,12 @@ import {AbstractComponent} from "../classes/abstract.component";
  * @param {object} options
  * @internal
  */
-export function Component(options: {
-	selector: string,
-	childrenSelectors?: string[],
-	template?: string,
-	templateUrl?: string,
-	templateCachingEnabled?: boolean,
-	restrict?: string
-}) {
-	return function <T extends { new(...args: any[]): {} }>(target: T) {
-		return class extends target {
-			constructor(...args: any[]) {
-				super();
-				(this as any as AbstractComponent).__options = options;
-			}
-		};
-	};
+export function Component<TOptions extends ComponentOptions = ComponentOptions>(options: TOptions) {
+  return <T extends Constructor<AbstractComponent>>(target: T) =>
+    class extends target {
+      constructor(...args: any[]) {
+        super();
+        (this as unknown as AbstractComponent<TOptions>).__options = options;
+      }
+    };
 }


### PR DESCRIPTION
Fixes #

## Proposed Changes

Hey there :)
I recently found out that `children` is of type `any` on AbstractComponent so I thought I send you a proposal to opt into more explicit typing if the iizuna user wishes to do so. The changes should be fully backwards compatible. Thought you might want to look into it. 

With these changes the following pattern would allow strict typing on the `children` property:

```ts
const config = {
  selector: "my-parent-selector",
  childrenSelectors: ["child", "child2"],
} as const;

@Component(config)
class MyComponent extends AbstractComponent<typeof config> {
  someMethod() {
    this.children; // suggests the available children
  }
}
```
