### PR TITLE
drop es5 support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,12 +8,12 @@
 	],
 	"compilerOptions": {
 		"noImplicitAny": true,
-		"target": "es5",
+		"target": "ES6",
 		"experimentalDecorators": true,
 		"module": "commonjs",
 		"declaration": true,
 		"outDir": "./lib",
 		"strict": false,
-		"lib": ["es5", "dom", "es2015.symbol"]
+		"lib": ["ES6", "dom", "es2015.symbol"]
 	}
 }


### PR DESCRIPTION
Changes compile target from `ES5` to `ES6` to avoid compiling down native JavaScript Classes. 

Perhaps it would be smarter to provide a separate `build.es6.js` file additionally to the `build.js` to avoid breaking changes. Just food for thought.