### PR TITLE
Event dispatcher

### DIFF
--- a/src/decorators/event-dispatcher.decorator.ts
+++ b/src/decorators/event-dispatcher.decorator.ts
@@ -1,0 +1,33 @@
+import { AbstractComponent } from "../classes/abstract.component";
+
+/**
+ * @description
+ * Dispatches a CustomEvent from the current component instance.
+ * The return value of the decorated method is the CustomEventInit of this CustomEvent.
+ * @param {string} name The event type.
+ * @constructor
+ */
+export function EventDispatcher<T, TComponent extends AbstractComponent>(name: string) {
+	function emit(elem: Element | undefined, config: T): T {
+		const customEventInit = { detail: config, bubbles: true } satisfies CustomEventInit<T>;
+		const event = new CustomEvent(name, customEventInit);
+		elem?.dispatchEvent(event);
+		return config;
+	}
+
+	return (_: TComponent, __: string, descriptor: TypedPropertyDescriptor<(...args: any[]) => T>) => {
+		if (!(descriptor.value instanceof Function)) {
+			throw new Error("EventDispatcher must be used as a decorator on a class method.");
+		}
+
+		const originalMethod = descriptor.value;
+
+		descriptor.value = function (...args: any[]) {
+			const self: AbstractComponent = this as any;
+			const result = originalMethod.apply(self, args);
+			return emit(self.element, result);
+		};
+
+		return descriptor;
+	};
+}

--- a/src/decorators/event-dispatcher.decorator.ts
+++ b/src/decorators/event-dispatcher.decorator.ts
@@ -9,9 +9,13 @@ import { AbstractComponent } from "../classes/abstract.component";
  */
 export function EventDispatcher<T, TComponent extends AbstractComponent>(name: string) {
 	function emit(elem: Element | undefined, config: T): T {
-		const customEventInit = { detail: config, bubbles: true } satisfies CustomEventInit<T>;
+		const customEventInit: CustomEventInit<T> = { detail: config, bubbles: true };
 		const event = new CustomEvent(name, customEventInit);
-		elem?.dispatchEvent(event);
+
+		if (elem) {
+			elem.dispatchEvent(event);
+		}
+
 		return config;
 	}
 

--- a/src/decorators/event-dispatcher.decorator.ts
+++ b/src/decorators/event-dispatcher.decorator.ts
@@ -7,9 +7,9 @@ import { AbstractComponent } from "../classes/abstract.component";
  * @param {string} name The event type.
  * @constructor
  */
-export function EventDispatcher<T, TComponent extends AbstractComponent>(name: string) {
-	function emit(elem: Element | undefined, config: T): T {
-		const customEventInit: CustomEventInit<T> = { detail: config, bubbles: true };
+export function EventDispatcher<TPayload, TComponent extends AbstractComponent>(name: string) {
+	function emit(elem: Element | undefined, config: TPayload): TPayload {
+		const customEventInit: CustomEventInit<TPayload> = { detail: config, bubbles: true };
 		const event = new CustomEvent(name, customEventInit);
 
 		if (elem) {
@@ -19,7 +19,7 @@ export function EventDispatcher<T, TComponent extends AbstractComponent>(name: s
 		return config;
 	}
 
-	return (_: TComponent, __: string, descriptor: TypedPropertyDescriptor<(...args: any[]) => T>) => {
+	return (_: TComponent, __: string, descriptor: TypedPropertyDescriptor<(...args: any[]) => TPayload>) => {
 		if (!(descriptor.value instanceof Function)) {
 			throw new Error("EventDispatcher must be used as a decorator on a class method.");
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ export {ElementAttribute} from "./decorators/element-attribute.decorator";
 export {EventListener} from "./decorators/event-listener.decorator";
 export {GlobalEventListener} from "./decorators/global-event-listener.decorator";
 export {WindowEventListener} from "./decorators/window-event-listener.decorator";
+export {EventDispatcher} from "./decorators/event-dispatcher.decorator";
 /**
  * useful functions
  */


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - adds a new Decorator to dispatch CustomEvents from the current Component instance upon invokation of the decorated method
  - The return value of the decorated method gets used as the payload on the `detail` property of the CustomEventInit
  - Keep in mind that this PR does not include tests for the new Decorator
